### PR TITLE
加快获取masters速度

### DIFF
--- a/ruskit/cluster.py
+++ b/ruskit/cluster.py
@@ -230,7 +230,9 @@ class Cluster(object):
 
     @property
     def masters(self):
-        return [i for i in self.nodes if i.is_master()]
+        nodes = self.nodes[0].nodes()
+        masters = set(n["addr"] for n in nodes if 'master' in n["flags"])
+        return [i for i in self.nodes if "{}:{}".format(i.host, i.port) in masters]
 
     def consistent(self):
         sig = set()

--- a/ruskit/cluster.py
+++ b/ruskit/cluster.py
@@ -50,12 +50,20 @@ class ClusterNode(object):
         self.r = redis.Redis(host, port, socket_timeout=socket_timeout)
         self.r.ping()
 
+        self._cached_node_info = None
+
     @classmethod
     def from_uri(cls, uri):
         if not uri.startswith("redis://"):
             uri = "redis://{}".format(uri)
         d = urlparse.urlparse(uri)
         return cls(d.hostname, d.port)
+
+    @classmethod
+    def from_info(cls, info):
+        node = cls.from_uri(info["addr"])
+        node._cached_node_info = info
+        return node
 
     def __repr__(self):
         return "ClusterNode<{}:{}>".format(self.host, self.port)
@@ -88,8 +96,9 @@ class ClusterNode(object):
 
     @property
     def node_info(self):
-        nodes = self.nodes()
-        return nodes[0]
+        if self._cached_node_info is None:
+            self._cached_node_info = self.nodes()[0]
+        return self._cached_node_info
 
     @property
     def slots(self):
@@ -218,7 +227,7 @@ class Cluster(object):
 
     @classmethod
     def from_node(cls, node):
-        nodes = [ClusterNode.from_uri(i["addr"]) for i in node.nodes()
+        nodes = [ClusterNode.from_info(i) for i in node.nodes()
                  if i["link_status"] != "disconnected"]
         return cls(nodes)
 
@@ -230,9 +239,7 @@ class Cluster(object):
 
     @property
     def masters(self):
-        nodes = self.nodes[0].nodes()
-        masters = set(n["addr"] for n in nodes if 'master' in n["flags"])
-        return [i for i in self.nodes if "{}:{}".format(i.host, i.port) in masters]
+        return [i for i in self.nodes if i.is_master()]
 
     def consistent(self):
         sig = set()


### PR DESCRIPTION
之前获取`Cluster`中每个节点信息(如是否为master)的时候, 所有节点都要cluster nodes一次.
现在改成只取一个节点cluster nodes的结果, 并缓存起来.
@maralla @wooparadog 