### PR TITLE
记录等待集群状态一致的时间

### DIFF
--- a/ruskit/cluster.py
+++ b/ruskit/cluster.py
@@ -280,8 +280,11 @@ class Cluster(object):
         return len(slots) == CLUSTER_HASH_SLOTS and self.consistent()
 
     def wait(self):
+        start = time.time()
         while not self.consistent():
             time.sleep(1)
+        logger.info('cluster took {} seconds to become consistent'.format(
+            time.time() - start))
 
         if not self.healthy():
             raise ClusterNotHealthy("Error: missing slots")


### PR DESCRIPTION
线上某些集群的变更操作(加master节点, 迁移槽位)变得非常慢, 怀疑集群花了很长时间来同步状态, 现在补上日志来记录.