### PR TITLE
pin redis dependency version and compate for redis 4.0.

### DIFF
--- a/ruskit/cluster.py
+++ b/ruskit/cluster.py
@@ -229,7 +229,7 @@ class ClusterNode(object):
             confs = item.split()
             node_info = {
                 "name": confs[0],
-                "addr": confs[1],
+                "addr": confs[1].split("@")[0],
                 "flags": confs[2].split(','),
                 "replicate": confs[3],  # master_id
                 "ping_sent": int(confs[4]),

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     },
     install_requires=[
         "hiredis",
-        "redis>=2.10.5",
+        "redis==2.10.5",
     ],
     extras_require={
         'addslaves': ['python-igraph'],


### PR DESCRIPTION
1. 锁定 redis 的依赖版本为 `2.10.5`。 `2.10.6` 不适配当前ruskit
2. 兼容 redis 4.0 的关于地址的特殊写法。
